### PR TITLE
fix: oidc authentication not opening browser.

### DIFF
--- a/openeo_plugin/gui/login_dialog.py
+++ b/openeo_plugin/gui/login_dialog.py
@@ -6,9 +6,7 @@ import time
 import sys
 import webbrowser
 import openeo
-import traceback
 
-#from qgis.PyQt import uic
 from qgis.PyQt import QtWidgets
 from qgis.PyQt.QtWidgets import QApplication
 from qgis.PyQt.QtWidgets import QMessageBox


### PR DESCRIPTION
The "Login failed as the connection is missing. Please try again."  was caused by an AttributeError of the user notification system on line 153, which was being accessed on the wrong attribute.
This caused the webbrowser.open() to be skipped and not allow for a login 