### PR TITLE
Temporary workaround for #148

### DIFF
--- a/openeo_plugin/utils/logging.py
+++ b/openeo_plugin/utils/logging.py
@@ -69,7 +69,9 @@ class Logging():
         if isinstance(error, Exception):
             message += f" Reason: {str(error)}"
 
-        self.messageLog.logMessage(message, self.tag, level, notifyUser=show)
+        debug = level == Qgis.Info and not show
+        if not debug or self.developerMode:
+            self.messageLog.logMessage(message, self.tag, level, notifyUser=show)
 
         if self.developerMode:
             title = self.getTitle(level, show)


### PR DESCRIPTION
The debug messages did show in the UI although notifyUser was set to False.

Seems this needs to be handled differently, so not sending debug messages right now (only if developer mode is activated).